### PR TITLE
Community Upgrade 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To upgrade, **install the new gaiad version** `v0.29.0` and download the new gen
 
 `gaiad start` with command line flags as appropriate for your node type.
 
+Genesis time will be 2018-12-20 15:00 UTC.
+
 ### Launch policy
 
 We are delaying Game of Stakes launch based on the demands of the validator community to run a 48hr testnet.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With 199 validators online, the signatures in blockheader now take up most of th
 
 We will be doing the first network upgrade.
 
-To upgrade, **install the new gaiad version** `v0.28.2` and download the new genesis to your config folder.
+To upgrade, **install the new gaiad version** `v0.29.0` and download the new genesis to your config folder.
 
 `gaiad unsafe-reset-all` <- this is safe since we are starting a new chain
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ chat here: [Riot](https://matrix.to/#/!RKBbCjMEiDPKKewRIE:matrix.org?via=matrix.
 
 ## Updates
 
+### Upgrade 1.
+>brought to you by Zaki and Certus One
+
+We chose a very conservative initial blocksize of `50kb` for the initial game of stakes launch as a conservative starting.
+
+With 199 validators online, the signatures in blockheader now take up most of the block.
+
+We will be doing the first network upgrade.
+
+To upgrade, **install the new gaiad version** `v0.28.2` and download the new genesis to your config folder.
+
+`gaiad unsafe-reset-all` <- this is safe since we are starting a new chain
+
+`gaiad start` with command line flags as appropriate for your node type.
+
 ### Launch policy
 
 We are delaying Game of Stakes launch based on the demands of the validator community to run a 48hr testnet.


### PR DESCRIPTION
At height 11443 the GoS chain was halted by a bug in the unbonding and fee distribution logic of the cosmos-sdk. Issue: https://github.com/cosmos/cosmos-sdk/issues/3160 ; Fix: https://github.com/cosmos/cosmos-sdk/pull/3163

Also the chain was already suffering from the small block size limit as described in the attached `README.md`

Since we cannot rely on on-chain governance anymore we are proposing this genesis file together with an upgrade to an upcoming new gaiad version that fixes the root cause

This is a state dump from height 11441 (2 blocks before the chain halted). The inconsistency is resolved in this genesis file, since all fees have automatically been withdrawn in the postprocessing step of `gaiad export`.

What this improves:
* It fixes the cause of the halt
* BlockSize is increased

To reproduce this file:

* Sync a node with pruning disabled to current `game_of_stakes`
* `gaiad start --pruning=nothing`
* `gaiad export --height 11441 --for-zero-height`
* Modify chain_id and blockSize

README text by @zmanian 

